### PR TITLE
Add detailed keyword to identify

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ $ python -q
 '1.11.2'
 >>> pygfried.identify("/bin/ls")
 'fmt/690'
+>>> pygfried.identify("/bin/ls", detailed=True)
+{'siegfried': '1.11.2', 'scandate': '2025-06-09T20:43:28+02:00', 'signature': 'default.sig', 'created': '2025-03-01T15:28:08+11:00', 'identifiers': [{'name': 'pronom', 'details': 'DROID_SignatureFile_V120.xml; container-signature-20240715.xml'}], 'files': [{'filename': '/bin/ls', 'filesize': 142312, 'modified': '2024-04-05T16:36:57+02:00', 'errors': '', 'matches': [{'ns': 'pronom', 'id': 'fmt/690', 'format': 'Executable and Linkable Format', 'version': '64bit Little Endian', 'mime': '', 'class': '', 'basis': 'byte match at 0, 7', 'warning': 'extension mismatch'}]}]}
 ```
 
 ## Limitations

--- a/pygfried/__init__.pyi
+++ b/pygfried/__init__.pyi
@@ -1,6 +1,11 @@
-from typing import Literal
-from typing import Union
+from typing import Union, Literal, Any
 
 class GoError: ...
-def identify(path: str) -> Union[Literal["UNKNOWN"], str, None]: ...
+
+SimpleIdentifyResult = Union[Literal["UNKNOWN"], str, None]
+DetailedIdentifyResult = Any
+
+def identify(
+    path: str, detailed: bool = False
+) -> Union[SimpleIdentifyResult, DetailedIdentifyResult]: ...
 def version() -> str: ...

--- a/pygfried_test.go
+++ b/pygfried_test.go
@@ -1,6 +1,7 @@
 package pygfried_test
 
 import (
+	"encoding/json"
 	"fmt"
 	"testing"
 
@@ -21,6 +22,37 @@ func TestIdentify(t *testing.T) {
 	})
 }
 
+func TestIdentifyWithJSON(t *testing.T) {
+	blob, err := pygfried.IdentifyWithJSON("setup.cfg")
+
+	assert.NilError(t, err)
+
+	type Match struct {
+		ID string `json:"id"`
+	}
+	type File struct {
+		Filename string  `json:"filename"`
+		Matches  []Match `json:"matches"`
+	}
+	type Response struct {
+		Files []File `json:"files"`
+	}
+
+	var response Response
+	err = json.Unmarshal([]byte(blob), &response)
+	assert.NilError(t, err)
+
+	assert.Equal(t, len(response.Files), 1)
+	assert.DeepEqual(t, response, Response{
+		Files: []File{
+			{
+				Filename: "setup.cfg",
+				Matches:  []Match{{ID: "UNKNOWN"}},
+			},
+		},
+	})
+}
+
 func TestIdentifyAll(t *testing.T) {
 	paths := []string{"README.md", "setup.cfg"}
 	results, err := pygfried.IdentifyAll(paths)
@@ -29,6 +61,42 @@ func TestIdentifyAll(t *testing.T) {
 	assert.DeepEqual(t, results, []*pygfried.Result{
 		{Path: "README.md", Identifiers: []string{"fmt/1149"}, Known: true},
 		{Path: "setup.cfg", Identifiers: []string{"UNKNOWN"}, Known: false},
+	})
+}
+
+func TestIdentifyAllWithJSON(t *testing.T) {
+	paths := []string{"README.md", "setup.cfg"}
+	blob, err := pygfried.IdentifyAllWithJSON(paths)
+
+	assert.NilError(t, err)
+
+	type Match struct {
+		ID string `json:"id"`
+	}
+	type File struct {
+		Filename string  `json:"filename"`
+		Matches  []Match `json:"matches"`
+	}
+	type Response struct {
+		Files []File `json:"files"`
+	}
+
+	var response Response
+	err = json.Unmarshal([]byte(blob), &response)
+	assert.NilError(t, err)
+
+	assert.Equal(t, len(response.Files), 2)
+	assert.DeepEqual(t, response, Response{
+		Files: []File{
+			{
+				Filename: "README.md",
+				Matches:  []Match{{ID: "fmt/1149"}},
+			},
+			{
+				Filename: "setup.cfg",
+				Matches:  []Match{{ID: "UNKNOWN"}},
+			},
+		},
 	})
 }
 

--- a/pylib/main.go
+++ b/pylib/main.go
@@ -5,6 +5,7 @@ package main
 // extern int Pygfried_PyArg_ParseTuple_U(PyObject*, PyObject**);
 // extern PyObject* Pygfried_Py_RETURN_NONE();
 // extern PyObject* Pygfried_GoError;
+// extern PyObject* Pygfried_json_loads(PyObject*);
 import "C"
 
 import (
@@ -65,6 +66,31 @@ func identify(self *C.PyObject, args *C.PyObject) *C.PyObject {
 	}
 
 	return stringToPyOrNone(res.Identifiers[0])
+}
+
+//export identify_with_json
+func identify_with_json(self *C.PyObject, args *C.PyObject) *C.PyObject {
+	path, err := goStringFromArgs(args)
+	if err != nil {
+		return raise(err)
+	}
+
+	jsonResult, err := pygfried.IdentifyWithJSON(path)
+	if err != nil {
+		return raise(err)
+	}
+
+	// Convert Go string to Python string
+	pyStr := stringToPy(jsonResult)
+	if pyStr == nil {
+		return raise(fmt.Errorf("Failed to convert string to Python object"))
+	}
+
+	// Parse JSON string into Python object using C function
+	result := C.Pygfried_json_loads(pyStr)
+	C.Py_DecRef(pyStr)
+
+	return result
 }
 
 //export version

--- a/pylib/support.c
+++ b/pylib/support.c
@@ -1,7 +1,8 @@
 #include <Python.h>
 
-/* Will come from Go */
+/* Will come from Go. */
 PyObject* identify(PyObject*, PyObject*);
+PyObject* identify_with_json(PyObject*, PyObject*);
 PyObject* version(PyObject*);
 
 /* To shim Go's missing variadic function support. */
@@ -17,9 +18,66 @@ PyObject* Pygfried_Py_RETURN_NONE() {
 /* Exception types. */
 PyObject* Pygfried_GoError;
 
+/* JSON loading function used by Go. */
+PyObject* Pygfried_json_loads(PyObject* json_str) {
+    PyObject* json_module = PyImport_ImportModule("json");
+    if (!json_module) {
+        return NULL;
+    }
+
+    PyObject* loads_func = PyObject_GetAttrString(json_module, "loads");
+    Py_DECREF(json_module);
+    if (!loads_func) {
+        return NULL;
+    }
+
+    PyObject* args = PyTuple_Pack(1, json_str);
+    PyObject* result = PyObject_CallObject(loads_func, args);
+    Py_DECREF(loads_func);
+    Py_DECREF(args);
+
+    return result;
+}
+
+static PyObject* pygfried_identify_wrapper(PyObject* self, PyObject* args, PyObject* kwargs) {
+    char* path_str = NULL;
+    PyObject* detailed_kwarg_obj = Py_False;
+    static char* kwlist[] = {"path", "detailed", NULL};
+
+    if (!PyArg_ParseTupleAndKeywords(args, kwargs, "s|O", kwlist, &path_str, &detailed_kwarg_obj)) {
+        return NULL;
+    }
+
+    int use_detailed = PyObject_IsTrue(detailed_kwarg_obj);
+    if (use_detailed == -1) {
+        return NULL;
+    }
+
+    PyObject* go_func_args = PyTuple_New(1);
+    if (!go_func_args) {
+        return NULL;
+    }
+    PyObject* py_path_str = PyUnicode_FromString(path_str);
+    if (!py_path_str) {
+        Py_DECREF(go_func_args);
+        return NULL;
+    }
+    PyTuple_SetItem(go_func_args, 0, py_path_str);
+
+    PyObject* result;
+    if (use_detailed) {
+        result = identify_with_json(self, go_func_args);
+    } else {
+        result = identify(self, go_func_args);
+    }
+
+    Py_DECREF(go_func_args);
+    return result;
+}
+
 static struct PyMethodDef methods[] = {
-    {"identify", (PyCFunction)identify, METH_VARARGS},
-    {"version", (PyCFunction)version, METH_VARARGS},
+    {"identify", (PyCFunction)pygfried_identify_wrapper, METH_VARARGS | METH_KEYWORDS},
+    {"version", (PyCFunction)version, METH_NOARGS},
     {NULL, NULL}
 };
 


### PR DESCRIPTION
As discussed in https://github.com/artefactual-labs/pygfried/issues/7:

```
>>> pygfried.identify("/bin/ls", detailed=True)
{'siegfried': '1.11.2', 'scandate': '2025-06-09T20:43:28+02:00', 'signature': 'default.sig', 'created': '2025-03-01T15:28:08+11:00', 'identifiers': [{'name': 'pronom', 'details': 'DROID_SignatureFile_V120.xml; container-signature-20240715.xml'}], 'files': [{'filename': '/bin/ls', 'filesize': 142312, 'modified': '2024-04-05T16:36:57+02:00', 'errors': '', 'matches': [{'ns': 'pronom', 'id': 'fmt/690', 'format': 'Executable and Linkable Format', 'version': '64bit Little Endian', 'mime': '', 'class': '', 'basis': 'byte match at 0, 7', 'warning': 'extension mismatch'}]}]}
```

The pylib/* stuff was done by Gemini 2.5 Pro. It would have taken me an entire week to do it myself!